### PR TITLE
Fixes a bug where the client configuration is lost in sub-operations.

### DIFF
--- a/wapiti/operations/base.py
+++ b/wapiti/operations/base.py
@@ -424,10 +424,10 @@ class Operation(object):
         origin_queue = self.subop_queues[oqi]
         is_recursive = origin_queue.options.get('is_recursive')
         if is_recursive:
-            origin_queue.enqueue_many(results)
+            origin_queue.enqueue_many(results, client=self.client)
         if dqi < len(self.subop_queues):
             dest_queue = self.subop_queues[dqi]
-            dest_queue.enqueue_many(results)
+            dest_queue.enqueue_many(results, client=self.client)
         else:
             new_res = self._update_results(results)
         return new_res
@@ -523,7 +523,7 @@ class QueryOperation(Operation):
         subop_queue = self.subop_queues[0]
         chunk_size = self.per_query_param_limit
         for chunk in chunked_iter(self.input_param_list, chunk_size):
-            subop_queue.enqueue(tuple(chunk))  # TODO
+            subop_queue.enqueue(tuple(chunk), client=self.client)  # TODO
         return
 
     @property

--- a/wapiti/operations/test_basic.py
+++ b/wapiti/operations/test_basic.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import base
 
+from misc import GetPageInfo
 from models import PageIdentifier
 from category import GetSubcategoryInfos
 
@@ -49,3 +50,16 @@ def test_get_meta():
     get_source_info = GetSourceInfo()
     meta = get_source_info()
     assert meta
+
+
+def test_client_passed_to_subops():
+    # This tests whether the client object given to the initial operation
+    # is passed to its sub-operations.
+
+    # Use just enough titles to force multiplexing so that we can get
+    # sub ops to test.
+    titles = ['a'] * (base.DEFAULT_QUERY_LIMIT.get_limit() + 1)
+
+    client = base.MockClient()
+    op = GetPageInfo(titles, client=client)
+    assert id(op.subop_queues[0].peek().client) == id(client)


### PR DESCRIPTION
I came across this when I was trying to launch a large request (>500 titles) with `is_bot=True`. The expected behavior is that this would chunk the requests into sizes suitable for a bot (500 titles per request), but it ended up chunking them into 50 titles per request. The cause of it seems to be that the client state is not always passed to sub operations, which means the initial configuration is lost (and `is_bot` reverts to its default `False`).

More insidiously, this ended up falling back to the default `MockClient` with the default web client---which sends your email address along with the request.

I also changed a few more places where ops were being enqueued without the client state being passed.

I've added a regression test that will fail if a sub-operation has a different client object than the one given initially. This only tests this condition when multiplexing occurs, but there are other places where things are enqueued that weren't getting the client state passed (like recursive queries).

I'm still finding my way around your code, so I don't know if this is the optimal fix. I debated between what I have now and adding `client` as a proper attribute of `OperationQueue`. I decided on what I have now because it was a smaller change, but it is less robust with respect to future uses of `enqueue` (you always have to remember to pass the client along). I'm happy to rework the fix if necessary!
