### PR TITLE
SingleParam(titles) -> MultiParam(titles) for GetCurrentContent

### DIFF
--- a/wapiti/operations/revisions.py
+++ b/wapiti/operations/revisions.py
@@ -52,7 +52,7 @@ class GetCurrentContent(QueryOperation):
     """
     Fetch full content for current (top) revision.
     """
-    input_field = SingleParam('titles', key_prefix=False, attr='title')
+    input_field = MultiParam('titles', key_prefix=False, attr='title')
     field_prefix = 'rv'
     fields = [StaticParam('prop', 'revisions'),
               MultiParam('prop', DEFAULT_PROPS + '|content'),


### PR DESCRIPTION
I'm thinking this might have been a typo? It seems the API supports
multiple titles _and_ the result extractor for GetCurrentContent
seems to be aware of it too.
